### PR TITLE
Set custom User-Agent header

### DIFF
--- a/code/SuSo.class
+++ b/code/SuSo.class
@@ -37,8 +37,9 @@ import requests
 from sfi import Macro, Data, Scalar, SFIToolkit
 
 # // Python globals:
-ajheader={'Content-type': 'application/json'}
-ajpheader={'Content-type': 'application/json-patch+json'}
+signature="python-susoapi/{}".format(wrapperver)
+ajheader={'User-Agent': signature, 'Content-type': 'application/json'}
+ajpheader={'User-Agent': signature, 'Content-type': 'application/json-patch+json'}
 
 def checkurl(url):
   try:


### PR DESCRIPTION
Consider sending a custom header with all your requests to the server. This will help identify the method of API access when analyzing server logs